### PR TITLE
Make contextmenu on context-menu close the context menu

### DIFF
--- a/js/d3-context-menu.js
+++ b/js/d3-context-menu.js
@@ -41,7 +41,13 @@
 				var elm = this;
 
 				d3.selectAll('.d3-context-menu').html('');
-				var list = d3.selectAll('.d3-context-menu').append('ul');
+				var list = d3.selectAll('.d3-context-menu')
+					.on('contextmenu', function(d) {
+						d3.select('.d3-context-menu').style('display', 'none'); 
+		  				d3.event.preventDefault();
+						d3.event.stopPropagation();
+					})
+					.append('ul');
 				list.selectAll('li').data(typeof menu === 'function' ? menu(data) : menu).enter()
 					.append('li')
 					.attr('class', function(d) {


### PR DESCRIPTION
Not sure if you'd want this, but I hate it when contextmenu clicking on a context menu (right click twice) opens the browser's menu. Dismissing the menu is what all of Google's web-app context menus do.

The option would be nice, at least.