### PR TITLE
load d3 from requirejs

### DIFF
--- a/js/d3-context-menu.js
+++ b/js/d3-context-menu.js
@@ -4,7 +4,18 @@
 			d3.contextMenu = factory(d3);
 			return d3.contextMenu;
 		};
-	} else {
+	} else if(typeof define === 'function' && define.amd) {
+		try {
+			var d3 = require('d3');
+		} catch (e) {
+			d3 = root.d3;
+		}
+
+		d3.contextMenu = factory(d3);
+		define([], function() {
+			return d3.contextMenu;
+		});
+	} else if(root.d3) {
 		root.d3.contextMenu = factory(root.d3);
 	}
 }(	this, 


### PR DESCRIPTION
d3 is being loaded from only commonjs and window.
So I added one more for amd, requirejs.
For some cases that using requiejs and not loading d3 in requirejs, added error handling when d3 is not loaded before loading d3-context-menu in requirejs, then d3 in window will be loaded.