### PR TITLE
v0.1.3 Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ The following example shows how to add a right click menu to a tree diagram:
 
 http://plnkr.co/edit/bDBe0xGX1mCLzqYGOqOS?p=info
 
+### What's new in version 0.1.3
+* Fixed issue where context menu element is never removed from DOM
+* Fixed issue where `<body>` click event is never removed
+* Fixed issue where the incorrect `onClose` callback was called when menu was closed as a result of clicking outside
+
 ### What's new in version 0.1.2
 
 * If contextmenu is clicked twice it will close rather than open the browser's context menu.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-context-menu",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": [
     "js/d3-context-menu.js",
     "css/d3-context-menu.css"

--- a/js/d3-context-menu.js
+++ b/js/d3-context-menu.js
@@ -18,7 +18,7 @@
 	} else if(root.d3) {
 		root.d3.contextMenu = factory(root.d3);
 	}
-}(	this, 
+}(	this,
 	function(d3) {
 		return function (menu, opts) {
 
@@ -33,29 +33,44 @@
 				closeCallback = opts.onClose;
 			}
 
-			// create the div element that will hold the context menu
-			d3.selectAll('.d3-context-menu').data([1])
-				.enter()
-				.append('div')
-				.attr('class', 'd3-context-menu');
+			var createMenu = function () {
+				// create the div element that will hold the context menu
+				d3.selectAll('.d3-context-menu').data([1])
+					.enter()
+					.append('div')
+					.attr('class', 'd3-context-menu');
+			};
 
-			// close menu
-			d3.select('body').on('click.d3-context-menu', function() {
-				d3.select('.d3-context-menu').style('display', 'none');
-				if (closeCallback) {
-					closeCallback();
+			var closeMenu = function () {
+				var contextMenuElm = d3.select('.d3-context-menu');
+				d3.select('body').on('click.d3-context-menu', null);
+
+				if (contextMenuElm.size() > 0) {
+					contextMenuElm.remove();
+
+					if (closeCallback) {
+						closeCallback();
+					}
 				}
-			});
+			};
 
 			// this gets executed when a contextmenu event occurs
 			return function(data, index) {
 				var elm = this;
 
-				d3.selectAll('.d3-context-menu').html('');
+				// close any menu that's already opened
+				closeMenu();
+
+				// create new menu container
+				createMenu();
+
+				// close menu on click outside
+				d3.select('body').on('click.d3-context-menu', closeMenu);
+
 				var list = d3.selectAll('.d3-context-menu')
 					.on('contextmenu', function(d) {
-						d3.select('.d3-context-menu').style('display', 'none'); 
-		  				d3.event.preventDefault();
+						closeMenu();
+						d3.event.preventDefault();
 						d3.event.stopPropagation();
 					})
 					.append('ul');
@@ -87,11 +102,7 @@
 						if (d.disabled) return; // do nothing if disabled
 						if (!d.action) return; // headers have no "action"
 						d.action(elm, data, index);
-						d3.select('.d3-context-menu').style('display', 'none');
-
-						if (closeCallback) {
-							closeCallback();
-						}
+						closeMenu();
 					});
 
 				// the openCallback allows an action to fire before the menu is displayed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-context-menu",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A plugin for d3.js that allows you to easily use context menus in your visualizations.",
   "main": "js/d3-context-menu.js",
   "directories": {


### PR DESCRIPTION
v0.1.3 patch
* Fixed issue where context menu element is never removed from DOM
* Fixed issue where `<body>` click event is never removed
* Fixed issue where the incorrect `onClose` callback was called when menu was closed as a result of clicking outside