### PR TITLE
v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ bower install d3-context-menu
 var menu = [
 	{
 		title: 'Item #1',
-		action: function(elm, d, i) {
+		action: function(d, i) {
 			console.log('Item #1 clicked!');
 			console.log('The data for this circle is: ' + d);
 		},
@@ -27,7 +27,7 @@ var menu = [
 	},
 	{
 		title: 'Item #2',
-		action: function(elm, d, i) {
+		action: function(d, i) {
 			console.log('You have clicked the second item!');
 			console.log('The data for this circle is: ' + d);
 		}
@@ -124,7 +124,7 @@ var menu = [
 		title: function(d) {
 			return 'Delete circle '+d.circleName;
 		},
-		action: function(elm, d, i) {
+		action: function(d, i) {
 			// delete it
 		}
 	},
@@ -132,7 +132,7 @@ var menu = [
 		title: function(d) {
 			return 'Item 2';
 		},
-		action: function(elm, d, i) {
+		action: function(d, i) {
 			// do nothing interesting
 		}
 	}
@@ -153,7 +153,7 @@ var menu = function(data) {
 	if (data.x > 100) {
 		return [{
 			title: 'Item #1',
-			action: function(elm, d, i) {
+			action: function(d, i) {
 				console.log('Item #1 clicked!');
 				console.log('The data for this circle is: ' + d);
 			}
@@ -161,13 +161,13 @@ var menu = function(data) {
 	} else {
 		return [{
 			title: 'Item #1',
-			action: function(elm, d, i) {
+			action: function(d, i) {
 				console.log('Item #1 clicked!');
 				console.log('The data for this circle is: ' + d);
 			}
 		}, {
 			title: 'Item #2',
-			action: function(elm, d, i) {
+			action: function(d, i) {
 				console.log('Item #2 clicked!');
 				console.log('The data for this circle is: ' + d);
 			}
@@ -217,7 +217,8 @@ or
 		onClose: function() {
 			...
 		},
-		position: function(d, elm, i) {
+		position: function(d, i) {
+			var elm = this;
 			var bounds = elm.getBoundingClientRect();
 
 			// eg. align bottom-left
@@ -230,9 +231,49 @@ or
 
 ```
 
+#### Set your own CSS class as theme (make sure to style it)
+
+```
+d3.contextMenu(menu, {
+	...
+	theme: 'my-awesome-theme'
+});
+```
+
+or
+
+```
+d3.contextMenu(menu, {
+	...
+	theme: function () {
+		if (foo) {
+			return 'my-foo-theme';
+		}
+		else {
+			return 'my-awesome-theme';
+		}
+	}
+});
+```
+
+#### Close the context menu programatically (can be used as cleanup, as well)
+
+```
+d3.contextMenu('close');
+```
+
 The following example shows how to add a right click menu to a tree diagram:
 
 http://plnkr.co/edit/bDBe0xGX1mCLzqYGOqOS?p=info
+
+### What's new in version 1.0.0
+* Default theme styles extracted to their own css class (`d3-context-menu-theme`)
+* Ability to specify own theme css class via the `theme` configuration option (as string or function returning string)
+* onOpen/onClose callbacks now have consistent signature (they receive `data` and `index`, and `this` argument refers to the DOM element the context menu is related to)
+* all other functions (eg. `position`, `menu`) have the same signature and `this` object as `onClose`/`onOpen`
+* Context menu now closes on `mousedown` outside of the menu, instead of `click` outside (to mimic behaviour of the native context menu)
+* `disabled` and `divider` can now be functions as well and have the same siganture and `this` object as explained above
+* Close the context menu programatically using `d3.contextMenu('close');`
 
 ### What's new in version 0.2.1
 * Ability to set menu position

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-context-menu",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "main": [
     "js/d3-context-menu.js",
     "css/d3-context-menu.css"

--- a/css/d3-context-menu.css
+++ b/css/d3-context-menu.css
@@ -7,6 +7,12 @@
 	z-index: 1200;
 }
 
+.d3-context-menu ul,
+.d3-context-menu ul li {
+	margin: 0;
+	padding: 0;
+}
+
 .d3-context-menu ul {
 	list-style-type: none;
 	cursor: default;
@@ -35,7 +41,7 @@
 */
 
 .d3-context-menu ul li.is-divider {
-	padding: 0px 0px;
+	padding: 0;
 }
 
 /* Theming
@@ -51,8 +57,7 @@
 }
 
 .d3-context-menu-theme ul {
-	margin: 4px 0px;
-	padding: 0px;
+	margin: 4px 0;
 }
 
 .d3-context-menu-theme ul li {

--- a/css/d3-context-menu.css
+++ b/css/d3-context-menu.css
@@ -1,27 +1,18 @@
+/* Layout
+------------ */
+
 .d3-context-menu {
 	position: absolute;
-	display: none;
-	background-color: #f2f2f2;
-	border-radius: 4px;
-
-	font-family: Arial, sans-serif;
-	font-size: 14px;
 	min-width: 150px;
-	border: 1px solid #d4d4d4;
-
-	z-index:1200;
+	z-index: 1200;
 }
 
 .d3-context-menu ul {
 	list-style-type: none;
-	margin: 4px 0px;
-	padding: 0px;
 	cursor: default;
 }
 
 .d3-context-menu ul li {
-	padding: 4px 16px;
-
 	-webkit-touch-callout: none; /* iOS Safari */
 	-webkit-user-select: none;   /* Chrome/Safari/Opera */
 	-khtml-user-select: none;    /* Konqueror */
@@ -30,31 +21,12 @@
 	user-select: none;
 }
 
-.d3-context-menu ul li:hover {
-	background-color: #4677f8;
-	color: #fefefe;
-}
-
-/*
-	Header
-*/
-
-.d3-context-menu ul li.is-header,
-.d3-context-menu ul li.is-header:hover {
-	background-color: #f2f2f2;
-	color: #444;
-	font-weight: bold;
-	font-style: italic;
-}
-
 /*
 	Disabled
 */
 
 .d3-context-menu ul li.is-disabled,
 .d3-context-menu ul li.is-disabled:hover {
-	background-color: #f2f2f2;
-	color: #888;
 	cursor: not-allowed;
 }
 
@@ -66,13 +38,65 @@
 	padding: 0px 0px;
 }
 
-.d3-context-menu ul li.is-divider:hover {
+/* Theming
+------------ */
+
+.d3-context-menu-theme {
+	background-color: #f2f2f2;
+	border-radius: 4px;
+
+	font-family: Arial, sans-serif;
+	font-size: 14px;
+	border: 1px solid #d4d4d4;
+}
+
+.d3-context-menu-theme ul {
+	margin: 4px 0px;
+	padding: 0px;
+}
+
+.d3-context-menu-theme ul li {
+	padding: 4px 16px;
+}
+
+.d3-context-menu-theme ul li:hover {
+	background-color: #4677f8;
+	color: #fefefe;
+}
+
+/*
+	Header
+*/
+
+.d3-context-menu-theme ul li.is-header,
+.d3-context-menu-theme ul li.is-header:hover {
+	background-color: #f2f2f2;
+	color: #444;
+	font-weight: bold;
+	font-style: italic;
+}
+
+/*
+	Disabled
+*/
+
+.d3-context-menu-theme ul li.is-disabled,
+.d3-context-menu-theme ul li.is-disabled:hover {
+	background-color: #f2f2f2;
+	color: #888;
+}
+
+/*
+	Divider
+*/
+
+.d3-context-menu-theme ul li.is-divider:hover {
 	background-color: #f2f2f2;
 }
 
-.d3-context-menu ul hr {
+.d3-context-menu-theme ul hr {
 	border: 0;
-    height: 0;
-    border-top: 1px solid rgba(0, 0, 0, 0.1);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+	height: 0;
+	border-top: 1px solid rgba(0, 0, 0, 0.1);
+	border-bottom: 1px solid rgba(255, 255, 255, 0.3);
 }

--- a/examples/index.htm
+++ b/examples/index.htm
@@ -8,46 +8,57 @@
 
 	<script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.4.11/d3.min.js"></script>
 	<script src="../js/d3-context-menu.js"></script>
+
+	<style>
+		.d3-context-menu-theme.dark {
+			background: black;
+			color: white;
+		}
+	</style>
 </head>
 <body>
 
 	<script>
+		var item4Disabled = false;
+		var useDarkTheme = false;
+		
 		// Define your menu
 		var menu = [
 
 			{
-				title: 'Item #1',
-				action: function(elm, d, i) {
-					console.log('Item #1 clicked!');
-					console.log('The data for this circle is: ' + d);
+				title: 'Toggle dark theme',
+				action: function (data, index) {
+					console.log('Item clicked', 'element:', this, 'data:', data, 'index:', index);
+					useDarkTheme = !useDarkTheme;
 				}
 			},
 			{
 				title: 'Item #2',
-				action: function(elm, d, i) {
-					console.log('You have clicked the second item!');
-					console.log('The data for this circle is: ' + d);
+				action: function (data, index) {
+					console.log('Item clicked', 'element:', this, 'data:', data, 'index:', index);
 				}
 			},
 
 			{
-				title: function() {
-					if (menu[3].disabled) {
+				title: function (data, index) {
+					if (item4Disabled) {
 						return 'Re-enable menu item #4';
 					} else {
 						return 'Disable menu item #4';
 					}
 				},
-				action: function(elm, d, i) {
-					menu[3].disabled = !menu[3].disabled;
+				action: function (data, index) {
+					console.log('Disabling item 4!', 'element:', this, 'data:', data, 'index:', index);
+					item4Disabled = !item4Disabled;
 				}
 			},
 			{
 				title: 'Item #4',
-				disabled: false,
-				action: function(elm, d, i) {
-					console.log('You have clicked the 4th item!');
-					console.log('The data for this circle is: ' + d);
+				disabled: function (data, index) {
+					return item4Disabled;
+				},
+				action: function (data, index) {
+					console.log('Item clicked', 'element:', this, 'data:', data, 'index:', index);
 				}
 			},
 
@@ -66,14 +77,13 @@
 			},
 			{
 				title: 'Last item',
-				action: function(elm, d, i) {
-					console.log('You have clicked the last item!');
-					console.log('The data for this circle is: ' + d);
+				action: function (data, index) {
+					console.log('Item clicked', 'element:', this, 'data:', data, 'index:', index);
 				}
 			},
 		]
 
-		var data = [1, 2, 3];
+		var data = ['red', 'green', 'steelblue'];
 
 		var g = d3.select('body').append('svg')
 			.attr('width', 200)
@@ -85,23 +95,33 @@
 			.enter()
 			.append('circle')
 			.attr('r', 30)
-			.attr('fill', 'steelblue')
+			.attr('fill', function (d) {
+				return d;
+			})
 			.attr('cx', function(d) {
 				return 100;
 			})
-			.attr('cy', function(d) {
-				return d * 100;
+			.attr('cy', function(d, i) {
+				return (i + 1) * 100;
 			})
 			.on('contextmenu', d3.contextMenu(menu, {
-				onOpen: function() {
-					console.log('opened!');
+				theme: function () {
+					if (useDarkTheme) {
+						return 'd3-context-menu-theme dark';
+					}
+					else {
+						return 'd3-context-menu-theme';
+					}
 				},
-				onClose: function() {
-					console.log('closed!');
+				onOpen: function (data, index) {
+					console.log('Menu Opened!', 'element:', this, 'data:', data, 'index:', index);
 				},
-				position: function (d, elm) {
-					var bounds = elm.getBoundingClientRect();
-					if (d === 1) {
+				onClose: function (data, index) {
+					console.log('Menu Closed!', 'element:', this, 'data:', data, 'index:', index);
+				},
+				position: function (data, index) {
+					var bounds = this.getBoundingClientRect();
+					if (data === 'green') {
 						// first circle will have the menu aligned top-right
 						return {
 							left: bounds.left + bounds.width + 10,

--- a/js/d3-context-menu.js
+++ b/js/d3-context-menu.js
@@ -18,72 +18,123 @@
 	} else if(root.d3) {
 		root.d3.contextMenu = factory(root.d3);
 	}
-}(	this,
-	function(d3) {
-		return function (menu, opts) {
+}(this,
+	function (d3) {
+		var utils = {
+			noop: function () {},
+			
+			/**
+			 * @param {*} value
+			 * @returns {Boolean}
+			 */
+			isFn: function (value) {
+				return typeof value === 'function';
+			},
 
-			var openCallback,
-				closeCallback,
-				positionProvider;
+			/**
+			 * @param {*} value
+			 * @returns {Function}
+			 */
+			const: function (value) {
+				return function () { return value; };
+			},
 
-			if (typeof opts === 'function') {
-				openCallback = opts;
-			} else {
-				opts = opts || {};
-				openCallback = opts.onOpen;
-				closeCallback = opts.onClose;
-				positionProvider = opts.position;
+			/**
+			 * @param {Function|*} value
+			 * @param {*} [fallback]
+			 * @returns {Function}
+			 */
+			toFactory: function (value, fallback) {
+				value = (value === undefined) ? fallback : value;
+				return utils.isFn(value) ? value : utils.const(value);
+			}
+		};
+
+		// global state for d3-context-menu
+		var d3ContextMenu = null;
+
+		var closeMenu = function () {
+			// global state is populated if a menu is currently opened
+			if (d3ContextMenu) {
+				d3.select('.d3-context-menu').remove();
+				d3.select('body').on('mousedown.d3-context-menu', null);
+				d3ContextMenu.boundCloseCallback();
+				d3ContextMenu = null;
+			}
+		};
+
+		/**
+		 * Calls API method (e.g. `close`) or
+		 * returns handler function for the `contextmenu` event
+		 * @param {Function|Array|String} menuItems
+		 * @param {Function|Object} config
+		 * @returns {?Function}
+		 */
+		return function (menuItems, config) {
+			// allow for `d3.contextMenu('close');` calls
+			// to programatically close the menu
+			if (menuItems === 'close') {
+				return closeMenu();
 			}
 
-			var createMenu = function () {
-				// create the div element that will hold the context menu
-				d3.selectAll('.d3-context-menu').data([1])
-					.enter()
-					.append('div')
-					.attr('class', 'd3-context-menu');
-			};
+			// for convenience, make `menuItems` a factory
+			// and `config` an object
+			menuItems = utils.toFactory(menuItems);
 
-			var closeMenu = function () {
-				var contextMenuElm = d3.select('.d3-context-menu');
-				d3.select('body').on('click.d3-context-menu', null);
+			if (utils.isFn(config)) {
+				config = { onOpen: config };
+			}
+			else {
+				config = config || {};
+			}
 
-				if (contextMenuElm.size() > 0) {
-					contextMenuElm.remove();
+			// resolve config
+			var openCallback = config.onOpen || utils.noop;
+			var closeCallback = config.onClose || utils.noop;
+			var positionFactory = utils.toFactory(config.position);
+			var themeFactory = utils.toFactory(config.theme, 'd3-context-menu-theme');
 
-					if (closeCallback) {
-						closeCallback();
-					}
-				}
-			};
-
-			// this gets executed when a contextmenu event occurs
-			return function(data, index) {
-				var elm = this;
+			/**
+			 * Context menu event handler
+			 * @param {*} data
+			 * @param {Number} index
+			 */
+			return function (data, index) {
+				var element = this;
 
 				// close any menu that's already opened
 				closeMenu();
 
-				// create new menu container
-				createMenu();
+				// store close callback already bound to the correct args and scope
+				d3ContextMenu = {
+					boundCloseCallback: closeCallback.bind(element, data, index)
+				};
 
-				// close menu on click outside
-				d3.select('body').on('click.d3-context-menu', closeMenu);
+				// create the div element that will hold the context menu
+				d3.selectAll('.d3-context-menu').data([1])
+					.enter()
+					.append('div')
+					.attr('class', 'd3-context-menu ' + themeFactory.bind(element)(data, index));
+
+				// close menu on mousedown outside
+				d3.select('body').on('mousedown.d3-context-menu', closeMenu);
 
 				var list = d3.selectAll('.d3-context-menu')
-					.on('contextmenu', function(d) {
+					.on('contextmenu', function() {
 						closeMenu();
 						d3.event.preventDefault();
 						d3.event.stopPropagation();
 					})
 					.append('ul');
-				list.selectAll('li').data(typeof menu === 'function' ? menu(data) : menu).enter()
+				
+				list.selectAll('li').data(menuItems.bind(element)(data, index)).enter()
 					.append('li')
 					.attr('class', function(d) {
 						var ret = '';
-						if (d.divider) {
+						if (utils.toFactory(d.divider).bind(element)(data, index)) {
 							ret += ' is-divider';
 						}
-						if (d.disabled) {
+						if (utils.toFactory(d.disabled).bind(element)(data, index)) {
 							ret += ' is-disabled';
 						}
 						if (!d.action) {
@@ -92,40 +143,34 @@
 						return ret;
 					})
 					.html(function(d) {
-						if (d.divider) {
+						if (utils.toFactory(d.divider).bind(element)(data, index)) {
 							return '<hr>';
 						}
 						if (!d.title) {
 							console.error('No title attribute set. Check the spelling of your options.');
 						}
-						return (typeof d.title === 'string') ? d.title : d.title(data);
+						return utils.toFactory(d.title).bind(element)(data, index);
 					})
 					.on('click', function(d, i) {
-						if (d.disabled) return; // do nothing if disabled
+						if (utils.toFactory(d.disabled).bind(element)(data, index)) return; // do nothing if disabled
 						if (!d.action) return; // headers have no "action"
-						d.action(elm, data, index);
+						d.action.bind(element)(data, index);
 						closeMenu();
 					});
 
 				// the openCallback allows an action to fire before the menu is displayed
 				// an example usage would be closing a tooltip
-				if (openCallback) {
-					if (openCallback(data, index) === false) {
-						return;
-					}
+				if (openCallback.bind(element)(data, index) === false) {
+					return;
 				}
 
 				// get position
-				var position = positionProvider;
-				if (typeof positionProvider === 'function') {
-					position = positionProvider(data, elm, index);
-				}
+				var position = positionFactory.bind(element)(data, index);
 
 				// display context menu
 				d3.select('.d3-context-menu')
 					.style('left', (position ? position.left : d3.event.pageX - 2) + 'px')
-					.style('top', (position ? position.top : d3.event.pageY - 2) + 'px')
-					.style('display', 'block');
+					.style('top', (position ? position.top : d3.event.pageY - 2) + 'px');
 
 				d3.event.preventDefault();
 				d3.event.stopPropagation();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-context-menu",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "description": "A plugin for d3.js that allows you to easily use context menus in your visualizations.",
   "main": "js/d3-context-menu.js",
   "directories": {


### PR DESCRIPTION
* Default theme styles extracted to their own css class (`d3-context-menu-theme`)
* Ability to specify own theme css class via the `theme` configuration option (as string or function returning string)
* onOpen/onClose callbacks now have consistent signature (they receive `data` and `index`, and `this` argument refers to the DOM element the context menu is related to)
* all other functions (eg. `position`, `menu`) have the same signature and `this` object as `onClose`/`onOpen`
* Context menu now closes on `mousedown` outside of the menu, instead of `click` outside (to mimic behaviour of the native context menu)
* `disabled` and `divider` can now be functions as well and have the same siganture and `this` object as explained above
* Close the context menu programatically using `d3.contextMenu('close');`