### PR TITLE
add support for D3 6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ bower install d3-context-menu
 var menu = [
 	{
 		title: 'Item #1',
-		action: function(d, i) {
+		action: function(d) {
 			console.log('Item #1 clicked!');
 			console.log('The data for this circle is: ' + d);
 		},
@@ -27,7 +27,7 @@ var menu = [
 	},
 	{
 		title: 'Item #2',
-		action: function(d, i) {
+		action: function(d) {
 			console.log('You have clicked the second item!');
 			console.log('The data for this circle is: ' + d);
 		}
@@ -160,7 +160,7 @@ var menu = [
 		title: function(d) {
 			return 'Delete circle '+d.circleName;
 		},
-		action: function(d, i) {
+		action: function(d) {
 			// delete it
 		}
 	},
@@ -168,7 +168,7 @@ var menu = [
 		title: function(d) {
 			return 'Item 2';
 		},
-		action: function(d, i) {
+		action: function(d) {
 			// do nothing interesting
 		}
 	}
@@ -189,7 +189,7 @@ var menu = function(data) {
 	if (data.x > 100) {
 		return [{
 			title: 'Item #1',
-			action: function(d, i) {
+			action: function(d) {
 				console.log('Item #1 clicked!');
 				console.log('The data for this circle is: ' + d);
 			}
@@ -197,13 +197,13 @@ var menu = function(data) {
 	} else {
 		return [{
 			title: 'Item #1',
-			action: function(d, i) {
+			action: function(d) {
 				console.log('Item #1 clicked!');
 				console.log('The data for this circle is: ' + d);
 			}
 		}, {
 			title: 'Item #2',
-			action: function(d, i) {
+			action: function(d) {
 				console.log('Item #2 clicked!');
 				console.log('The data for this circle is: ' + d);
 			}
@@ -253,7 +253,7 @@ or
 		onClose: function() {
 			...
 		},
-		position: function(d, i) {
+		position: function(d) {
 			var elm = this;
 			var bounds = elm.getBoundingClientRect();
 
@@ -301,6 +301,10 @@ d3.contextMenu('close');
 The following example shows how to add a right click menu to a tree diagram:
 
 http://plnkr.co/edit/bDBe0xGX1mCLzqYGOqOS?p=info
+
+### What's new in version 1.1.3
+* Added support for D3 6.x
+* The `index` parameter of callbacks are undefined when using D3 6.x or above. See the index.htm file in the example folder to see how to get the proper `index` value in that case.
 
 ### What's new in version 1.1.2
 * Menu updated so it wont go off bottom or right of screen when window is smaller.

--- a/examples/index.htm
+++ b/examples/index.htm
@@ -6,7 +6,7 @@
 
 	<link href="../css/d3-context-menu.css" rel="stylesheet">
 
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.4.11/d3.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.2.0/d3.min.js"></script>
 	<script src="../js/d3-context-menu.js"></script>
 
 	<style>
@@ -27,37 +27,41 @@
 
 			{
 				title: 'Toggle dark theme',
-				action: function (data, index) {
+				action: function (data) {
+					var index = selection.nodes().indexOf(this);
 					console.log('Item clicked', 'element:', this, 'data:', data, 'index:', index);
 					useDarkTheme = !useDarkTheme;
 				}
 			},
 			{
 				title: 'Item #2',
-				action: function (data, index) {
+				action: function (data) {
+					var index = selection.nodes().indexOf(this);
 					console.log('Item clicked', 'element:', this, 'data:', data, 'index:', index);
 				}
 			},
 
 			{
-				title: function (data, index) {
+				title: function (data) {
 					if (item4Disabled) {
 						return 'Re-enable menu item #4';
 					} else {
 						return 'Disable menu item #4';
 					}
 				},
-				action: function (data, index) {
+				action: function (data) {
+					var index = selection.nodes().indexOf(this);
 					console.log('Disabling item 4!', 'element:', this, 'data:', data, 'index:', index);
 					item4Disabled = !item4Disabled;
 				}
 			},
 			{
 				title: 'Item #4',
-				disabled: function (data, index) {
+				disabled: function (data) {
 					return item4Disabled;
 				},
-				action: function (data, index) {
+				action: function (data) {
+					var index = selection.nodes().indexOf(this);
 					console.log('Item clicked', 'element:', this, 'data:', data, 'index:', index);
 				}
 			},
@@ -112,13 +116,13 @@
 							return colors.map(function(color) {
 								return {
 									title: color,
-									action: function (data, index) {
+									action: function (data) {
 										console.log('color changed from ' + data + ' to ' + color);
 										d3.select(this)
 											.datum(color)
 											.attr('fill', color);
 									},
-									disabled: function (data, index) {
+									disabled: function (data) {
 										return data === color;
 									}
 								}
@@ -129,7 +133,8 @@
 			},
 			{
 				title: 'Last item',
-				action: function (data, index) {
+				action: function (data) {
+					var index = selection.nodes().indexOf(this);
 					console.log('Item clicked', 'element:', this, 'data:', data, 'index:', index);
 				}
 			},
@@ -142,7 +147,7 @@
 			.attr('height', 400)
 			.append('g');
 
-		g.selectAll('circles')
+		var selection = g.selectAll('circles')
 			.data(data)
 			.enter()
 			.append('circle')
@@ -155,8 +160,9 @@
 			})
 			.attr('cy', function(d, i) {
 				return (i + 1) * 100;
-			})
-			.on('contextmenu', d3.contextMenu(menu, {
+			});
+
+		selection.on('contextmenu', d3.contextMenu(menu, {
 				theme: function () {
 					if (useDarkTheme) {
 						return 'd3-context-menu-theme dark';
@@ -165,13 +171,15 @@
 						return 'd3-context-menu-theme';
 					}
 				},
-				onOpen: function (data, index) {
+				onOpen: function (data) {
+					var index = selection.nodes().indexOf(this);
 					console.log('Menu Opened!', 'element:', this, 'data:', data, 'index:', index);
 				},
-				onClose: function (data, index) {
+				onClose: function (data) {
+					var index = selection.nodes().indexOf(this);
 					console.log('Menu Closed!', 'element:', this, 'data:', data, 'index:', index);
 				},
-				position: function (data, index) {
+				position: function (data) {
 					var bounds = this.getBoundingClientRect();
 					if (data === 'green') {
 						// first circle will have the menu aligned top-right

--- a/js/d3-context-menu.js
+++ b/js/d3-context-menu.js
@@ -94,11 +94,27 @@
 
 			/**
 			 * Context menu event handler
-			 * @param {*} data
-			 * @param {Number} index
+			 * @param {*} param1
+			 * @param {*} param2
 			 */
-			return function (data, index) {
+			return function (param1, param2) {
 				var element = this;
+
+				var event, data, index;
+				if (d3.event === undefined) {
+					// Using D3 6.x or above
+					event = param1;
+					data = param2;
+
+					// We cannot tell the index properly in new D3 versions,
+					// since it is not possible to access the original selection.
+					index = undefined;
+				} else {
+					// Using D3 5.x or below
+					event = d3.event;
+					data = param1;
+					index = param2;
+				}
 
 				// close any menu that's already opened
 				closeMenu();
@@ -121,8 +137,8 @@
 				var parent = d3.selectAll('.d3-context-menu')
 					.on('contextmenu', function() {
 						closeMenu();
-						d3.event.preventDefault();
-						d3.event.stopPropagation();
+						event.preventDefault();
+						event.stopPropagation();
 					})
 					.append('ul');
 
@@ -145,21 +161,21 @@
 
 				var horizontalAlignment = 'left';
 				var horizontalAlignmentReset = 'right';
-				var horizontalValue = position ? position.left : d3.event.pageX - 2;
-				if (d3.event.pageX > pageWidth/2){
+				var horizontalValue = position ? position.left : event.pageX - 2;
+				if (event.pageX > pageWidth/2){
 					horizontalAlignment = 'right';
 					horizontalAlignmentReset = 'left';
-					horizontalValue = position ? pageWidth - position.left : pageWidth - d3.event.pageX - 2;
+					horizontalValue = position ? pageWidth - position.left : pageWidth - event.pageX - 2;
 				} 
 				
 
 				var verticalAlignment = 'top';
 				var verticalAlignmentReset = 'bottom';
-				var verticalValue = position ? position.top : d3.event.pageY - 2;
-				if (d3.event.pageY > pageHeight/2){
+				var verticalValue = position ? position.top : event.pageY - 2;
+				if (event.pageY > pageHeight/2){
 					verticalAlignment = 'bottom';
 					verticalAlignmentReset = 'top';
-					verticalValue = position ? pageHeight - position.top : pageHeight - d3.event.pageY - 2	;
+					verticalValue = position ? pageHeight - position.top : pageHeight - event.pageY - 2;
 				} 
 
 				// display context menu
@@ -170,8 +186,8 @@
 					.style(verticalAlignmentReset, null)
 					.style('display', 'block');
 
-				d3.event.preventDefault();
-				d3.event.stopPropagation();
+				event.preventDefault();
+				event.stopPropagation();
 
 
 				function createNestedMenu(parent, root, depth = 0) {


### PR DESCRIPTION
Fixes #55 

The main problem with D3 6.x is that it seems to be no longer possible to access the `index` parameter from event handlers without knowing the original selection.
This PR adds D3 support without `index` support, but I've updated the `example/index.htm` file to show how to get the proper `index` when using new D3 versions. I think users of D3 6.x will already be familiar with this method, as it is a global change with all event handlers.

I've thought about removing the `index` parameter from callbacks, but that would be a larger breaking change, and the workaround to get the index only works from D3 4.x versions. (With D3 3.x selections do not have a `nodes()` function which is used).

So I think this is probably the best way to add support for 6.x without sacrificing compatibility with older versions. What do you think?